### PR TITLE
Re-added pronunciation-related links dropped off in wikipedia quote.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # thirteen
-#### (13, XIII, 十三, trece, तेरह, ثلاثة عشر, тринадцать, treze, dreizehn, baker's dozen, 11012, שלוש עשרה)
+#### (13, XIII, 十三, trece, तेरह, ثلاثة عشر, тринадцать, treze, dreizehn, baker's dozen, 11012)
 
 ![](http://3.bp.blogspot.com/-HwVI7rIAKcA/UrDM_76QemI/AAAAAAAAFRs/FafL0KW80r0/s1600/13feliz.gif)
 
@@ -9,7 +9,7 @@ and multiply by [thirteen][13].
 From [Wikipedia][13]:
 > 13 (thirteen /θɜrˈtiːn/) is the natural number following 12 and preceding 14.
 
-> In spoken English, the numbers 13 and 30 are often confused. When carefully enunciated, they differ in which syllable is stressed: 13 Listeni/θərˈtiːn/ vs. 30 /ˈθɜrti/. However, in dates such as 1300 ("thirteen hundred") or when contrasting numbers in the teens, such as 13, 14, 15, the stress shifts to the first syllable: 13 /ˈθɜrtiːn/.
+> In spoken English, the numbers 13 and 30 are often confused. When carefully enunciated, they differ in which syllable is stressed: 13 [![Listen](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Speakerlink-new.svg/22px-Speakerlink-new.svg.png)](https://upload.wikimedia.org/wikipedia/commons/0/06/En-us-thirteen.ogg) [/θərˈtiːn/][not13] vs. 30 [/ˈθɜrti/][not13]. However, in dates such as 1300 ("thirteen hundred") or when contrasting numbers in the teens, such as 13, 14, 15, the stress shifts to the first syllable: 13 [/ˈθɜrtiːn/][not13].
 
 ## Installation
 
@@ -39,3 +39,4 @@ grunt test
 See [CONTRIBUTING.MD](CONTRIBUTING.md)
 
 [13]:http://en.wikipedia.org/wiki/13_(number)
+[not13]:https://en.wikipedia.org/wiki/Help:IPA_for_English


### PR DESCRIPTION
As per original wikipedia format.

Effective pronunciation is important, but difficult. Proper examples [![Listen](https://upload.wikimedia.org/wikipedia/commons/thumb/3/3b/Speakerlink-new.svg/22px-Speakerlink-new.svg.png)](https://upload.wikimedia.org/wikipedia/commons/0/06/En-us-thirteen.ogg) are very helpful!
(As is linking to explanation that may, for some people, help turn IPA formatting into something slightly more meaningful more than 100% gibberish.)