### PR TITLE
Trim "!"s and parse to Number for accurate tests.

### DIFF
--- a/test/index.js
+++ b/test/index.js
@@ -7,11 +7,14 @@ describe('thirteen', function () {
   });
 
   it('should return its argument multiplied by thirteen', function () {
-    expect(thirteen(10)).to.eql(130);
+    // Cast to number from string for test comparison. Test will pass even if value is returned with more force (i.e. "130!!!!!!!!").
+    var returnedAsNumber = parseFloat(thirteen(10).replace(/\!/g, ""));
+    expect(returnedAsNumber).to.eql(130);
   });
 
   it('should NOT return its argument multiplied by twelve', function () {
-    expect(thirteen(10)).to.not.eql(120);
+    var returnedAsNumber = parseFloat(thirteen(10).replace(/\!/g, ""));
+    expect(returnedAsNumber).to.not.eql(120);
   });
 
   it('should return its arguments number-like value multiplied by thirteen', function () {
@@ -25,4 +28,3 @@ describe('thirteen', function () {
     expect(thirteen(wannabeValue)).to.eql(169);
   });
 });
-


### PR DESCRIPTION
The tests checking for a corrected returned output were failing because the call `thirteen(10)` will yield the string "130!!!" Therefore,  `expect(thirteen(10)).to.equal(130)` would fail when it should pass. 
In addition, the third test `expect(thirteen(10)).to.equal(120)` was failing (correctly) but because` "130!!! !== 120` when in reality it should fail because `130 !== 120'. 

Kept function intact and only adjusted return value in test for accurate comparison to a number type. All tests passing. 

![screen shot 2015-08-22 at 10 57 26 pm](https://cloud.githubusercontent.com/assets/8270120/9427169/48681826-4922-11e5-9e11-a686e4d3b9bf.png)
